### PR TITLE
Handle machineId if passed as anchor

### DIFF
--- a/js/demo.js
+++ b/js/demo.js
@@ -18,6 +18,7 @@ function onConnect() {
   $('#txtHost').text(host);
   $('#txtPort').text(port);
   $('#txtMachineId').text(machineid);
+  localStorage['machineid'] = machineid;
 }
 
 // called when the client loses its connection
@@ -33,6 +34,14 @@ function onMessageArrived(message) {
 }
 
 $(document).ready(function() {
+
+    if (window.location.hash) {
+        machineid = window.location.hash.substring(1);
+        window.location.hash = "";
+    } else {
+        machineid = localStorage['machineid'];
+    }
+    $('#machineid').val(machineid);
 
     $('#buttonConnect').on('click', function (e) {
          e.preventDefault();


### PR DESCRIPTION
Then link can be generated from device configuration page as:

http://demo.anavi.technology/#DEADBEEFDEADBEEFDEADBEEFDEADBEEF

It could be easier to user than copying the code.
For security purpose, as soon the page is loaded,
the code is moved to localstorage.

Change-Id: Iae36e56594634f14e8719d486cba5e4b2942042c
Signed-off-by: Philippe Coval <rzr@users.sf.net>